### PR TITLE
docs: pick methods belong to Deck, not DeckGL

### DIFF
--- a/docs/get-started/interactivity.md
+++ b/docs/get-started/interactivity.md
@@ -126,7 +126,7 @@ class App extends React.Component {
 
 ## Calling the Picking Engine Directly
 
-The picking engine is exposed through the [`DeckGL.pickObject`](/docs/api-reference/react/deckgl.md) and [`DeckGL.pickObjects`](/docs/api-reference/react/deckgl.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle. They return `Picking Info` objects as described below.
+The picking engine is exposed through the [`Deck.pickObject`](/docs/api-reference/deck.md) and [`Deck.pickObjects`](/docs/api-reference/deck.md) methods. These methods allow you to query what layers and objects within those layers are under a specific point or within a specified rectangle. They return `Picking Info` objects as described below.
 
 `pickObject` allows an application to define its own event handling. When it comes to how to actually do event handling in a browser, there are many options. In a React application, perhaps the simplest is to just use React's "synthetic" event handling together with `pickObject`:
 


### PR DESCRIPTION
For #2658 (first section)

#### Background
Page linked from documentation doesn't actually have any information on the picking methods mentioned.

#### Change List
- Just at this line, change "DeckGL" to "Deck",
- and point at the "Deck" documentation page.

Perhaps an anchored link would be better?
Apologies again if I'm confused.
